### PR TITLE
Update python Kafka client in order to manage secured Kafka broker 

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -5,14 +5,13 @@ Please note that this tool can be used for unit testing, but should not be used 
 ## Default Settings
 
 * default topic: raw.log.localtest or avro.log.localtest
-* kafka host: localhost:9092
-* zookeeper host: localhost:2181
+* kafka host: localhost:9092 or localhost:9093 for secured brokers using SSL
 
 ## Requirements
 
-* python 2.7
+* python 2.7.4
 * pip modules
-    * kafka-python (0.9.3)
+    * kafka-python (1.3.1)
     * avro (1.7.7)
     * optional for random text: loremipsum (1.0.5)
 
@@ -24,7 +23,7 @@ These files are a simple illustration of a producer and consumer written in Pyth
 
 * raw  option - topic is raw.log.localtest
 * avro option - topic is avro.log.localtest
-* Work with a local kafka / zk setup (localhost:2181, localhost:9092)
+* Work with a local kafka (localhost:9092 or localhost:9093)
 * Edit the python file for others hosts settings
 
 ## Consumer
@@ -41,6 +40,10 @@ Start a consumer (serializer - avro and extra header matching confluent.io schem
 
     python consumer.py -s true -e true
 
+Same with a secured kafka cluster
+
+	python consumer-ssl.py 
+
 ## Producer
 
 Start a producer (avro serializer is always on):
@@ -54,3 +57,7 @@ Start a producer (avro serializer is always on - extra header):
 Start a producer (avro serializer is always on - loop mode):
 
     python producer.py -e true -l true
+
+Start a producer with a secured kafka cluster
+
+	python producer.py -z

--- a/python/consumer.py
+++ b/python/consumer.py
@@ -95,7 +95,7 @@ class Consumer(threading.Thread):
     if( sslEnable):
       print("seeting up SSL to PROTOCOL_TLSv1")
       ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-      ctx.load_cert_chain(certfile="../../streamset/ca-cert", keyfile="../../streamset/ca-key", password="test1234")
+      ctx.load_cert_chain(certfile="../ca-cert", keyfile="../ca-key", password="test1234")
       consumer = KafkaConsumer(bootstrap_servers=["ip6-localhost:9093"],security_protocol="SSL",ssl_context=ctx)
     else:
       consumer = KafkaConsumer(bootstrap_servers=["ip6-localhost:9092"])

--- a/python/consumer.py
+++ b/python/consumer.py
@@ -92,7 +92,7 @@ class Consumer(threading.Thread):
 
     print("on topic %s" % topic)
 
-    if( sslEnable):
+    if(sslEnable):
       print("seeting up SSL to PROTOCOL_TLSv1")
       ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
       ctx.load_cert_chain(certfile="../ca-cert", keyfile="../ca-key", password="test1234")

--- a/python/consumer.py
+++ b/python/consumer.py
@@ -36,7 +36,7 @@ schema_id = 23
 schema = avro.schema.parse(open(schema_path).read())
 useextra = False
 useavro = False
-sslEnable=False
+sslEnable = False
 
 def consume_message(message):
 
@@ -92,11 +92,12 @@ class Consumer(threading.Thread):
 
     print("on topic %s" % topic)
 
-    if(sslEnable):
-      print("seeting up SSL to PROTOCOL_TLSv1")
+    if sslEnable:
+      print("setting up SSL to PROTOCOL_TLSv1")
       ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
       ctx.load_cert_chain(certfile="../ca-cert", keyfile="../ca-key", password="test1234")
-      consumer = KafkaConsumer(bootstrap_servers=["ip6-localhost:9093"],security_protocol="SSL",ssl_context=ctx)
+      consumer = KafkaConsumer(bootstrap_servers=["ip6-localhost:9093"],security_protocol="SASL_SSL",ssl_context=ctx,\
+    sasl_mechanism="PLAIN",sasl_plain_username="test",sasl_plain_password="test", group_id="test")
     else:
       consumer = KafkaConsumer(bootstrap_servers=["ip6-localhost:9092"])
 
@@ -118,7 +119,7 @@ class Consumer(threading.Thread):
           print('-'*60)
 
 def main(argv):
-  global useavro, useextra
+  global useavro, useextra, sslEnable
   try:
     opts, args = getopt.getopt(argv,"he:sz",["extra=", "serialized="])
   except getopt.GetoptError:

--- a/python/consumer.py
+++ b/python/consumer.py
@@ -27,8 +27,8 @@ import getopt
 from StringIO import StringIO
 import avro.schema
 import avro.io
-from kafka.client import KafkaClient
-from kafka.consumer import SimpleConsumer
+from kafka import KafkaConsumer, TopicPartition
+import ssl
 
 # Path to user.avsc avro schema
 schema_path = "./dataplatform-raw.avsc"
@@ -36,15 +36,17 @@ schema_id = 23
 schema = avro.schema.parse(open(schema_path).read())
 useextra = False
 useavro = False
+sslEnable=False
 
 def consume_message(message):
 
-  newmessage = message[1][3]
+  print(message)
+  newmessage = message.value
   if not useavro and not useextra:
-    print(message[1][3])
+    print(message.value)
   else:
     print('<'*10)
-    b = bytearray(message[1][3])
+    b = bytearray(newmessage)
     if b[0] != 0:
       print('-'*60)
       print("MAGIC_BYTE error")
@@ -80,7 +82,7 @@ class Consumer(threading.Thread):
 
   @classmethod
   def run(self):
-    global useavro, useextra, schema_id
+    global useavro, useextra, schema_id, sslEnable
     print("start Consumer")
 
     if useavro: 
@@ -88,12 +90,22 @@ class Consumer(threading.Thread):
     else:
      topic="raw.log.localtest"
 
-    client = KafkaClient("ip6-localhost:9092")
-    consumer = SimpleConsumer(client, "py-user-avro", topic)
+    print("on topic %s" % topic)
+
+    if( sslEnable):
+      print("seeting up SSL to PROTOCOL_TLSv1")
+      ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+      ctx.load_cert_chain(certfile="../../streamset/ca-cert", keyfile="../../streamset/ca-key", password="test1234")
+      consumer = KafkaConsumer(bootstrap_servers=["ip6-localhost:9093"],security_protocol="SSL",ssl_context=ctx)
+    else:
+      consumer = KafkaConsumer(bootstrap_servers=["ip6-localhost:9092"])
+
+    consumer.assign([TopicPartition(topic, 0)])
+
     ## Skip the consumer to the head of the log - this is a personal choice
     ## It mean we are loosing messages when the py consumer was off
     ## Not a problem for testing purposes
-    consumer.seek(0,2)
+    #consumer.seek(0,2)
 
     for message in consumer:
       print('-'*60)
@@ -108,7 +120,7 @@ class Consumer(threading.Thread):
 def main(argv):
   global useavro, useextra
   try:
-    opts, args = getopt.getopt(argv,"he:s:",["extra=", "serialized="])
+    opts, args = getopt.getopt(argv,"he:sz",["extra=", "serialized="])
   except getopt.GetoptError:
     print('consumer.py [-e|--extra true] [-a|--avro true]')
     sys.exit(2)
@@ -123,6 +135,9 @@ def main(argv):
     elif opt in ("-s", "--serialized"):
      print('avro serialization required')
      useavro=True
+    elif opt in ("-z"):
+      print('SSL required')
+      sslEnable=True
 
 
 if __name__ == "__main__":

--- a/python/producer.py
+++ b/python/producer.py
@@ -67,7 +67,7 @@ extrabytes = bytes('')
 
 if( sslEnable):
   ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-  ctx.load_cert_chain(certfile="../../streamset/ca-cert", keyfile="../../streamset/ca-key", password="test1234")
+  ctx.load_cert_chain(certfile="../ca-cert", keyfile="..//ca-key", password="test1234")
   producer = KafkaProducer(bootstrap_servers=["ip6-localhost:9093"],security_protocol="SSL",ssl_context=ctx)
 else:
   producer = KafkaProducer(bootstrap_servers=["ip6-localhost:9092"])

--- a/python/producer.py
+++ b/python/producer.py
@@ -65,10 +65,13 @@ for opt, arg in opts:
 
 extrabytes = bytes('')
 
-if( sslEnable):
+if sslEnable:
+  print("setting up SSL to PROTOCOL_TLSv1")
   ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-  ctx.load_cert_chain(certfile="../ca-cert", keyfile="..//ca-key", password="test1234")
-  producer = KafkaProducer(bootstrap_servers=["ip6-localhost:9093"],security_protocol="SSL",ssl_context=ctx)
+  ctx.load_cert_chain(certfile="../ca-cert", keyfile="../ca-key", password="test1234")
+  producer = KafkaProducer(bootstrap_servers=["ip6-localhost:9093"],security_protocol="SASL_SSL",\
+    ssl_context=ctx,\
+    sasl_mechanism="PLAIN",sasl_plain_username="test",sasl_plain_password="test")
 else:
   producer = KafkaProducer(bootstrap_servers=["ip6-localhost:9092"])
 


### PR DESCRIPTION
Update python Kafka client in order to manage secured Kafka broker and also move to a newer version of kafka-python as SimpleConsumer/Producer is deprecated. So use KafkaConsumer/Producer which do not use Zookeeper anymore.
